### PR TITLE
48 1.8 choose kind of event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -53,6 +53,6 @@ class EventsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def event_params
-      params.require(:event).permit(:name, :description, :max_participants, :active)
+      params.require(:event).permit(:name, :description, :max_participants, :active, :kind)
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,4 +14,6 @@ class Event < ActiveRecord::Base
   has_many :application_letters
 
   validates :max_participants, numericality: { only_integer: true, greater_than: 0 }
+
+  enum kind: [ :workshop, :camp ]
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -16,6 +16,18 @@
   <% end %>
 
   <div class="form-group">
+    <div class="btn-group col-lg-10 col-lg-offset-2" data-toggle="buttons">
+      <% Event.kinds.keys.each do |key| %>
+        <label class="btn btn-default <%= 'active' if @event.kind == key %>">
+          <%= f.radio_button :kind, key %>
+          <%= key.humanize %>
+        </label>
+      <% end %>
+    </div>
+    <%=f.error_span(:kind) %>
+  </div>
+
+  <div class="form-group">
     <%= f.label :name, :class => 'control-label col-lg-2' %>
     <div class="col-lg-10">
       <%= f.text_field :name, :class => 'form-control' %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,6 @@
 <%- model_class = Event -%>
 <div class="page-header">
-  <h1><%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+  <h1><%= @event.kind.humanize %> <%=t '.title', :default => model_class.model_name.human.titleize %></h1>
 </div>
 
 <dl class="dl-horizontal">

--- a/db/migrate/20161126113138_add_kind_to_events.rb
+++ b/db/migrate/20161126113138_add_kind_to_events.rb
@@ -1,0 +1,5 @@
+class AddKindToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :kind, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123124500) do
+ActiveRecord::Schema.define(version: 20161126113138) do
 
   create_table "application_letters", force: :cascade do |t|
     t.string   "motivation"
@@ -29,8 +29,9 @@ ActiveRecord::Schema.define(version: 20161123124500) do
     t.string   "description"
     t.integer  "max_participants"
     t.boolean  "active"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.integer  "kind",             default: 0
   end
 
   create_table "profiles", force: :cascade do |t|

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe EventsController, type: :controller do
   # This should return the minimal set of attributes required to create a valid
   # Event. As you add validations to Event, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { FactoryGirl.build(:event).attributes }
+  let(:valid_attributes) { FactoryGirl.attributes_for(:event) }
 
-  let(:invalid_attributes) { FactoryGirl.build(:event, max_participants: "twelve").attributes }
+  let(:invalid_attributes) { FactoryGirl.attributes_for(:event, max_participants: "twelve") }
 
   # This should return the minimal set of values that should be in the session
   # in order to pass any filters (e.g. authentication) defined in

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -16,6 +16,7 @@ FactoryGirl.define do
     name "Event-Name"
     description "Event-Description"
     max_participants 1
+    kind :workshop
     active false
   end
 end

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "Event", type: :feature do
+  describe "create page" do
+    it "should allow picking the event kind camp" do
+      visit new_event_path
+      fill_in 'Max participants', :with => 25
+      choose('Camp')
+      click_button "Event erstellen"
+      expect(page).to have_text('Camp')
+    end
+
+    it "should allow picking the event kind workshop" do
+      visit new_event_path
+      fill_in 'Max participants', :with => 25
+      choose('Workshop')
+      click_button "Event erstellen"
+      expect(page).to have_text('Workshop')
+    end
+  end
+end
+

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -18,5 +18,25 @@ describe "Event", type: :feature do
       expect(page).to have_text('Workshop')
     end
   end
+
+  describe "show page" do
+    it "should display the event kind" do
+      event = FactoryGirl.create(:event, kind: :workshop)
+      visit event_path(event)
+      expect(page).to have_text('Workshop')
+
+      event = FactoryGirl.create(:event, kind: :camp)
+      visit event_path(event)
+      expect(page).to have_text('Camp')
+    end
+  end
+
+  describe "edit page" do
+    it "should preselect the event kind" do
+      event = FactoryGirl.create(:event, kind: :camp)
+      visit edit_event_path(event)
+      expect(find_field('Camp')[:checked]).to_not be_nil
+    end
+  end
 end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -19,4 +19,15 @@ describe Event do
     event = FactoryGirl.build(:event)
     expect(event).to be_valid
   end
+
+  it "is either a camp or a workshop" do
+    expect { FactoryGirl.build(:event, kind: :smth_invalid) }.to raise_error(ArgumentError)
+
+    event = FactoryGirl.build(:event, kind: :camp)
+    expect(event).to be_valid
+
+    event = FactoryGirl.build(:event, kind: :workshop)
+    expect(event).to be_valid
+  end
+
 end


### PR DESCRIPTION
Adds a radiobutton toggle for choosing event kind.

One note for event_controller_spec:
`FactoryGirl.build(...).attributes` is not actually the correct way to receive the attribute list, but `FactoryGirl.attributes_for` is (matters when you want to use enums). https://github.com/thoughtbot/factory_girl/issues/680