### PR TITLE
20 2.4 profile information coaches can view others applications

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,7 +42,7 @@ class Ability
     if user.role? :tutor
       # Tutors can view Applications for Event
       can [:view_applicants], Event
-      can [:view_and_add_notes], ApplicationLetter
+      can [:view_and_add_notes, :show], ApplicationLetter
     end
     if user.role? :organizer
       can [:index, :show], Profile

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -65,10 +65,29 @@ describe User do
       ability = Ability.new(user)
 
       expect(ability).to_not be_able_to(:edit, another_application)
-      expect(ability).to_not be_able_to(:show, another_application)
       expect(ability).to_not be_able_to(:update, another_application)
       expect(ability).to_not be_able_to(:destroy, another_application)
     end
+  end
+
+  it "cannot see another user's application as pupil" do
+    user = FactoryGirl.create(:user, role: :pupil)
+    another_user = FactoryGirl.create(:user)
+    another_application = FactoryGirl.create(:application_letter, user: another_user)
+    ability = Ability.new(user)
+
+
+    expect(ability).to_not be_able_to(:show, another_application)
+  end
+
+  it "can see another user's application as tutor" do
+    user = FactoryGirl.create(:user, role: :tutor)
+    another_user = FactoryGirl.create(:user)
+    another_application = FactoryGirl.create(:application_letter, user: another_user)
+    ability = Ability.new(user)
+
+
+    expect(ability).to be_able_to(:show, another_application)
   end
 
   %i[tutor organizer].each do |role|


### PR DESCRIPTION
From our understanding coaches/tutors should be able to view application letters of other users, which is prohibited by the current implementation.