### PR TITLE
Fix the "Add default value to application status" migration

### DIFF
--- a/db/migrate/20161129120651_add_default_value_to_application_status.rb
+++ b/db/migrate/20161129120651_add_default_value_to_application_status.rb
@@ -1,5 +1,6 @@
 class AddDefaultValueToApplicationStatus < ActiveRecord::Migration
   def change
-	  change_column :application_letters, :status, :integer, null: false, default: 2
+	  change_column :application_letters, :status, :integer, default: 2
+    change_column_null :application_letters, :status, false, 2
   end
 end

--- a/db/migrate/20161129120651_add_default_value_to_application_status.rb
+++ b/db/migrate/20161129120651_add_default_value_to_application_status.rb
@@ -1,6 +1,6 @@
 class AddDefaultValueToApplicationStatus < ActiveRecord::Migration
   def change
-	  change_column :application_letters, :status, :integer, default: 2
+    change_column :application_letters, :status, :integer, default: 2
     change_column_null :application_letters, :status, false, 2
   end
 end


### PR DESCRIPTION
Make sure to use `change_column_null` to add the `NOT NULL` constraint.
Otherwise existing rows with `status` = `NULL` will cause the migration to fail.

Please note that this has no impact on people who have already run  the migration. Also, this change doesn't change anything on the schema itself. I am well aware that you normally shouldn't change migrations, but this should be an exception.