### PR TITLE
55 3.14 send emails backend avoid bcc

### DIFF
--- a/app/mailers/portal_mailer.rb
+++ b/app/mailers/portal_mailer.rb
@@ -6,12 +6,8 @@ class PortalMailer < ApplicationMailer
   # @param subject [String] - subject of the mail
   # @param content [String] - content of the mail
   # @return [ActionMailer::MessageDelivery] a mail object with the given parameters.
-  def generic_email(hide_recipients, recipients, reply_to, subject, content)
+  def generic_email(recipients, reply_to, subject, content)
     @content = content
-    if (hide_recipients)
-      mail(bcc: recipients, reply_to: reply_to, subject: subject)
-    else
-      mail(to: recipients, reply_to: reply_to, subject: subject)
-    end
+    mail(to: recipients, reply_to: reply_to, subject: subject)
   end
 end

--- a/app/mailers/portal_mailer.rb
+++ b/app/mailers/portal_mailer.rb
@@ -1,6 +1,5 @@
 class PortalMailer < ApplicationMailer
-
-  # @param hide_recipients [Boolean] - identify whether recipients should be hidden from each other (true) or not (false)
+  
   # @param recipients [Array<String>] - email addresses of recipients
   # @param reply_to [Array<String>] - email addresses of recipient of the answer
   # @param subject [String] - subject of the mail

--- a/app/mailers/portal_mailer.rb
+++ b/app/mailers/portal_mailer.rb
@@ -1,7 +1,7 @@
 class PortalMailer < ApplicationMailer
   
-  # @param recipients [Array<String>] - email addresses of recipients
-  # @param reply_to [Array<String>] - email addresses of recipient of the answer
+  # @param recipients [Array<String>] - email addresses of recipients - can be a string of comma separated email adresses too
+  # @param reply_to [Array<String>] - email addresses of recipient of the answer - can be a string of comma separated email adresses too
   # @param subject [String] - subject of the mail
   # @param content [String] - content of the mail
   # @return [ActionMailer::MessageDelivery] a mail object with the given parameters.

--- a/app/services/mailer.rb
+++ b/app/services/mailer.rb
@@ -1,4 +1,11 @@
 class Mailer
+
+  # @param hide_recipients - a boolean. `true` will send an email to the recipients one by one, `false` will send an email to all at once
+  # @param recipients [Array<String>] - email addresses of recipients - can be a string of comma separated email adresses too
+  # @param reply_to [Array<String>] - email addresses of recipient of the answer - can be a string of comma separated email adresses too
+  # @param subject [String] - subject of the mail
+  # @param content [String] - content of the mail
+  # @return [ActionMailer::MessageDelivery] a mail object with the given parameters.
   def self.send_generic_email(hide_recipients, recipients, reply_to, subject, content)
     if hide_recipients
       if recipients.is_a? String

--- a/app/services/mailer.rb
+++ b/app/services/mailer.rb
@@ -1,0 +1,11 @@
+class Mailer
+  def send_generic_email(hide_recipients, recipients, reply_to, subject, content)
+    if hide_recipients
+      recipients.each do |recipient|
+        PortalMailer.generic_email(recipient, reply_to, subject, content).deliver_now
+      end
+    else
+      PortalMailer.generic_email(recipients, reply_to, subject, content).deliver_now
+    end
+  end
+end

--- a/app/services/mailer.rb
+++ b/app/services/mailer.rb
@@ -1,5 +1,5 @@
 class Mailer
-  def send_generic_email(hide_recipients, recipients, reply_to, subject, content)
+  def self.send_generic_email(hide_recipients, recipients, reply_to, subject, content)
     if hide_recipients
       if recipients.is_a? String
         recipients = recipients.lines(',')

--- a/app/services/mailer.rb
+++ b/app/services/mailer.rb
@@ -1,6 +1,9 @@
 class Mailer
   def send_generic_email(hide_recipients, recipients, reply_to, subject, content)
     if hide_recipients
+      if recipients.is_a? String
+        recipients = recipients.lines(',')
+      end
       recipients.each do |recipient|
         PortalMailer.generic_email(recipient, reply_to, subject, content).deliver_now
       end

--- a/spec/mailers/portal_mailer_spec.rb
+++ b/spec/mailers/portal_mailer_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PortalMailer, type: :mailer do
   let(:subject) {'Subject'}
   let(:content) {'Awesome content'}
 
-  describe 'mail sending with direct addressing' do
-    let(:mail) { described_class.generic_email(false, recipients, reply_to, subject, content).deliver_now }
+  describe 'mail creation' do
+    let(:mail) { described_class.generic_email(recipients, reply_to, subject, content) }
 
     it 'sets the subject' do
       expect(mail.subject).to eq(subject)
@@ -15,10 +15,6 @@ RSpec.describe PortalMailer, type: :mailer do
 
     it 'sets the receiver email' do
       expect(mail.to).to eq(recipients)
-    end
-
-    it 'sets the bcc receiver email' do
-      expect(mail.bcc).to be_nil
     end
 
     it 'sets the reply_to email' do
@@ -31,18 +27,6 @@ RSpec.describe PortalMailer, type: :mailer do
 
     it 'sets the content' do
       expect(mail.body.encoded).to match(content)
-    end
-  end
-
-  describe 'mail sending with bcc addressing' do
-    let(:mail) { described_class.generic_email(true, recipients, reply_to, subject, content).deliver_now }
-
-    it 'sets the receiver email' do
-      expect(mail.to).to be_nil
-    end
-
-    it 'sets the bcc receiver email' do
-      expect(mail.bcc).to eq(recipients)
     end
   end
 end

--- a/spec/mailers/previews/portal_mailer_preview.rb
+++ b/spec/mailers/previews/portal_mailer_preview.rb
@@ -1,6 +1,6 @@
 # Preview all emails at http://localhost:3000/rails/mailers/portal_mailer
 class PortalMailerPreview < ActionMailer::Preview
   def generic_email_preview
-    PortalMailer.generic_email(true, "receiver@example.com", "reply@to.me", "This is subject", "This is content")
+    PortalMailer.generic_email("receiver@example.com", "reply@to.me", "This is subject", "This is content")
   end
 end

--- a/spec/services/mailer_spec.rb
+++ b/spec/services/mailer_spec.rb
@@ -1,37 +1,51 @@
 require "rails_helper"
 
 RSpec.describe Mailer, type: :service do
-  let(:recipients) { ['test@example.de', 'test2@example.de'] }
   let(:recipients_string) { 'test@example.de, test2@example.de' }
+  let(:recipients_array) { recipients_string.lines(',') }
   let(:reply_to) { ['test3@example.de'] }
   let(:subject) {'Subject'}
   let(:content) {'Awesome content'}
 
   describe 'mail sending with direct addressing' do
-    it 'sends right amount of emails' do
-      expect{Mailer.send_generic_email(false, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(1)
+    it 'sends right amount of emails with an array of recipients given' do
+      expect{Mailer.send_generic_email(false, recipients_array, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(1)
+    end
+
+    it 'sends right amount of emails with a string of recipients given' do
+      expect{Mailer.send_generic_email(false, recipients_string, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(1)
+    end
+
+    it 'has the correct number of recipients with an array of recipients given' do
+      Mailer.send_generic_email(false, recipients_array, reply_to, subject, content)
+      expect(ActionMailer::Base.deliveries.last.to.count).to eq(recipients_array.count)
+    end
+
+    it 'has the correct number of recipients with a string of recipients given' do
+      Mailer.send_generic_email(false, recipients_string, reply_to, subject, content)
+      expect(ActionMailer::Base.deliveries.last.to.count).to eq(recipients_array.count)
     end
   end
 
   describe 'mail sending with indirect addressing' do
-    it 'sends right amount of emails' do
-      expect{Mailer.send_generic_email(true, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
+    it 'sends right amount of emails with an array of recipients given' do
+      expect{Mailer.send_generic_email(true, recipients_array, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients_array.count)
     end
 
-    it 'sends right amount of emails' do
-      expect{Mailer.send_generic_email(true, recipients_string, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
+    it 'sends right amount of emails with a string of recipients given' do
+      expect{Mailer.send_generic_email(true, recipients_string, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients_array.count)
     end
 
-    it 'hides recipients from each other with array' do
-      Mailer.send_generic_email(true, recipients, reply_to, subject, content)
-      ActionMailer::Base.deliveries.last(recipients.count).each do |delivery|
+    it 'hides recipients from each other with an array of recipients given' do
+      Mailer.send_generic_email(true, recipients_array, reply_to, subject, content)
+      ActionMailer::Base.deliveries.last(recipients_array.count).each do |delivery|
         expect(delivery.to.count).to eq(1)
       end
     end
 
-    it 'hides recipients from each other with string' do
+    it 'hides recipients from each other with a string of recipients given' do
       Mailer.send_generic_email(true, recipients_string, reply_to, subject, content)
-      ActionMailer::Base.deliveries.last((recipients_string.count ',') + 1).each do |delivery|
+      ActionMailer::Base.deliveries.last(recipients_array.count).each do |delivery|
         expect(delivery.to.count).to eq(1)
       end
     end

--- a/spec/services/mailer_spec.rb
+++ b/spec/services/mailer_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Mailer, type: :service do
   let(:recipients) { ['test@example.de', 'test2@example.de'] }
+  let(:recipients_string) { 'test@example.de, test2@example.de' }
   let(:reply_to) { ['test3@example.de'] }
   let(:subject) {'Subject'}
   let(:content) {'Awesome content'}
@@ -18,9 +19,20 @@ RSpec.describe Mailer, type: :service do
       expect{mailer.send_generic_email(true, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
     end
 
-    it 'hides recipients from each other' do
+    it 'sends right amount of emails' do
+      expect{mailer.send_generic_email(true, recipients_string, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
+    end
+
+    it 'hides recipients from each other with array' do
       mailer.send_generic_email(true, recipients, reply_to, subject, content)
       ActionMailer::Base.deliveries.last(recipients.count).each do |delivery|
+        expect(delivery.to.count).to eq(1)
+      end
+    end
+
+    it 'hides recipients from each other with string' do
+      mailer.send_generic_email(true, recipients_string, reply_to, subject, content)
+      ActionMailer::Base.deliveries.last((recipients_string.count ',') + 1).each do |delivery|
         expect(delivery.to.count).to eq(1)
       end
     end

--- a/spec/services/mailer_spec.rb
+++ b/spec/services/mailer_spec.rb
@@ -6,32 +6,31 @@ RSpec.describe Mailer, type: :service do
   let(:reply_to) { ['test3@example.de'] }
   let(:subject) {'Subject'}
   let(:content) {'Awesome content'}
-  let(:mailer)  {described_class.new}
 
   describe 'mail sending with direct addressing' do
     it 'sends right amount of emails' do
-      expect{mailer.send_generic_email(false, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(1)
+      expect{Mailer.send_generic_email(false, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(1)
     end
   end
 
   describe 'mail sending with indirect addressing' do
     it 'sends right amount of emails' do
-      expect{mailer.send_generic_email(true, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
+      expect{Mailer.send_generic_email(true, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
     end
 
     it 'sends right amount of emails' do
-      expect{mailer.send_generic_email(true, recipients_string, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
+      expect{Mailer.send_generic_email(true, recipients_string, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
     end
 
     it 'hides recipients from each other with array' do
-      mailer.send_generic_email(true, recipients, reply_to, subject, content)
+      Mailer.send_generic_email(true, recipients, reply_to, subject, content)
       ActionMailer::Base.deliveries.last(recipients.count).each do |delivery|
         expect(delivery.to.count).to eq(1)
       end
     end
 
     it 'hides recipients from each other with string' do
-      mailer.send_generic_email(true, recipients_string, reply_to, subject, content)
+      Mailer.send_generic_email(true, recipients_string, reply_to, subject, content)
       ActionMailer::Base.deliveries.last((recipients_string.count ',') + 1).each do |delivery|
         expect(delivery.to.count).to eq(1)
       end

--- a/spec/services/mailer_spec.rb
+++ b/spec/services/mailer_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Mailer, type: :service do
+  let(:recipients) { ['test@example.de', 'test2@example.de'] }
+  let(:reply_to) { ['test3@example.de'] }
+  let(:subject) {'Subject'}
+  let(:content) {'Awesome content'}
+  let(:mailer)  {described_class.new}
+
+  describe 'mail sending with direct addressing' do
+    it 'sends right amount of emails' do
+      expect{mailer.send_generic_email(false, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(1)
+    end
+  end
+
+  describe 'mail sending with indirect addressing' do
+    it 'sends right amount of emails' do
+      expect{mailer.send_generic_email(true, recipients, reply_to, subject, content)}.to change{ActionMailer::Base.deliveries.count}.by(recipients.count)
+    end
+
+    it 'hides recipients from each other' do
+      mailer.send_generic_email(true, recipients, reply_to, subject, content)
+      ActionMailer::Base.deliveries.last(recipients.count).each do |delivery|
+        expect(delivery.to.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If recipients of an email should not know of each other, we now send multiple emails with to adressing instead of one with bcc. We do that in order to avoid a spam classification