### PR TITLE
hotfix to allow accepting and rejecting applications

### DIFF
--- a/app/views/application_letters/_application_selective.html.erb
+++ b/app/views/application_letters/_application_selective.html.erb
@@ -1,4 +1,4 @@
-<% if can? :edit_applicants, Event and application_letter.event.application_status_locked == false %>
+<% if can? :edit_applicants, Event and not (application_letter.event.application_status_locked == true) %>
     <%= form_for :application_letter, url: application_letter_path(application_letter), html: {method: :put} do |f| %>
         <div class="form-group">
           <div class="btn-group">


### PR DESCRIPTION
someone recently added "application_status_locked" as an attribute to the event model. From what i have seen, this value is not set on creating an event. This made it impossible to accept or reject applications, since the formular was only shown when application_status_locked is false, but it is nil or not set per default. Now it also shows on nil/not set