### PR TITLE
Remove Id column in requests#index and put link on topic instead

### DIFF
--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -5,7 +5,6 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th><%= model_class.human_attribute_name(:id) %></th>
       <th><%= model_class.human_attribute_name(:topics) %></th>
       <th><%= model_class.human_attribute_name(:user_id) %></th>
       <th><%= model_class.human_attribute_name(:created_at) %></th>
@@ -15,8 +14,7 @@
   <tbody>
     <% @requests.each do |request| %>
       <tr>
-        <td><%= link_to request.id, request_path(request) %></td>
-        <td><%= request.topics %></td>
+        <td><%= link_to request.topics, request_path(request) %></td>
         <td><%= request.user_id %></td>
         <td><%=l request.created_at %></td>
         <td>

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "Request", type: :feature do
+  describe "index page" do
+    it "should link to the show page when a request topic is clicked" do
+      request = FactoryGirl.create :request
+      visit requests_path
+      click_link request.topics
+      expect(page).to have_current_path(request_path(request))
+    end
+  end
+end

--- a/spec/views/requests/index.html.erb_spec.rb
+++ b/spec/views/requests/index.html.erb_spec.rb
@@ -13,4 +13,9 @@ RSpec.describe "requests/index", type: :view do
     render
     assert_select "tr>td", :text => @topics, :count => 2
   end
+
+  it "shouldn't have an id displayed" do
+    render
+    expect(rendered).to_not have_text("Id")
+  end
 end


### PR DESCRIPTION
Still relates to #115, after discussion with our PO it became clear that the Id is not wanted in any table. This is the only one  I could find apart from events