### PR TITLE
Add support for markdown. Fixes #258.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,9 @@ gem 'figaro'
 # Allow ORM functionality in plain ruby models
 gem 'active_attr'
 
+# Markdown renderer
+gem 'redcarpet'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.3.0)
+    redcarpet (3.4.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.4)
@@ -326,6 +327,7 @@ DEPENDENCIES
   puma
   rails (= 4.2.7.1)
   rails_12factor
+  redcarpet
   rspec-rails (~> 3.2)
   rubocop (~> 0.29.1)
   simplecov

--- a/app/assets/stylesheets/events.css
+++ b/app/assets/stylesheets/events.css
@@ -46,6 +46,9 @@
 .event-preview h3 {
     margin-top: 0;
 }
+.event-preview p {
+    overflow: hidden;
+}
 .event-date {
     text-align: center;
     line-height: 3em;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,43 @@
+require 'redcarpet'
+require 'redcarpet/render_strip'
+
+# Very barebone "markdown" renderer that ignores all elements
+# except paragraphs
+class MarkdownRenderTruncate < Redcarpet::Render::Base
+  def paragraph(text)
+    text + '<br>'
+  end
+end
+
 module ApplicationHelper
   def menu_items
     (menu_item t(:events, scope: 'navbar'), events_path) +
     (menu_item t(:requests, scope: 'navbar'), requests_path)
+  end
+
+  # Render the given string as markdown
+  #
+  # @param text String containing markdown
+  # @param truncatable boolean leave only paragraph elements
+  # @return string html_safe rendered markdown
+  def markdown(text, truncatable = false)
+    renderer = truncatable ?
+      MarkdownRenderTruncate.new :
+      Redcarpet::Render::HTML.new({
+        filter_html: true,
+        hard_wrap: true,
+        tables: true,
+        strikethrough: true,
+        link_attributes: { rel: 'nofollow', target: "_blank" },
+        space_after_headers: true,
+        fenced_code_blocks: true
+      })
+
+    Redcarpet::Markdown.new(renderer, {
+      autolink: true,
+      superscript: true,
+      disable_indented_code_blocks: true
+    }).render(text).html_safe
   end
 
   def dropdown_items

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,11 @@ require 'redcarpet/render_strip'
 # except paragraphs
 class MarkdownRenderTruncate < Redcarpet::Render::Base
   def paragraph(text)
-    text + '<br>'
+    text + ' '
+  end
+
+  def link(link, title, content)
+    content
   end
 end
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -16,7 +16,7 @@
     </small>
   </h3>
 
-  <p><%= truncate(event.description, length: Event::TRUNCATE_DESCRIPTION_TEXT_LENGTH) do
+  <p><%= truncate(markdown(event.description, true), length: Event::TRUNCATE_DESCRIPTION_TEXT_LENGTH) do
     link_to " " + I18n.t('events.list.read_on'), event_path(event)
   end %></p>
 

--- a/app/views/events/_show_event.html.erb
+++ b/app/views/events/_show_event.html.erb
@@ -3,7 +3,7 @@
   <dt><strong><%= model_class.human_attribute_name(:name) %>:</strong></dt>
   <dd><%= @event.name %></dd>
   <dt><strong><%= model_class.human_attribute_name(:description) %>:</strong></dt>
-  <dd><%= @event.description %></dd>
+  <dd><%= markdown @event.description %></dd>
   <dt><strong><%= model_class.human_attribute_name(:max_participants) %>:</strong></dt>
   <dd><%= @event.max_participants %></dd>
   <dt><strong><%= model_class.human_attribute_name(:date_ranges, count: @event.date_ranges.count) %>:</strong></dt>

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -51,6 +51,14 @@ describe "Event", type: :feature do
       expect(page).to_not have_text(I18n.t("events.notices.deadline_approaching", count: 10))
     end
 
+    it "should strip markdown from the description" do
+      FactoryGirl.create :event, description: "# Headline Test\nParagraph"
+      visit events_path
+      expect(page).to_not have_css('h1', text: 'Headline Test')
+      expect(page).to_not have_text('# Headline Test')
+      expect(page).to have_text('Paragraph')
+    end
+
     it "should truncate the description text if it's long" do
       FactoryGirl.create :event, description: ('a' * Event::TRUNCATE_DESCRIPTION_TEXT_LENGTH) + 'blah'
       visit events_path
@@ -177,6 +185,12 @@ describe "Event", type: :feature do
         visit event_path(event)
         expect(page).to have_text(kind.to_s.humanize)
       end
+    end
+
+    it "should render markdown for the description" do
+      event = FactoryGirl.create(:event, description: "# Test Headline")
+      visit event_path(event)
+      expect(page).to have_css("h1", text: "Test Headline")
     end
 
     it "should display a single day date range as a single date" do

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -52,11 +52,11 @@ describe "Event", type: :feature do
     end
 
     it "should strip markdown from the description" do
-      FactoryGirl.create :event, description: "# Headline Test\nParagraph"
+      FactoryGirl.create :event, description: "# Headline Test\nParagraph with a [link](http://portal.edu)."
       visit events_path
       expect(page).to_not have_css('h1', text: 'Headline Test')
-      expect(page).to_not have_text('# Headline Test')
-      expect(page).to have_text('Paragraph')
+      expect(page).to_not have_text('Headline Test')
+      expect(page).to have_text('Paragraph with a link.')
     end
 
     it "should truncate the description text if it's long" do


### PR DESCRIPTION
Adds redcarpet (markdown renderer) as a dependency.

The description on the event page will now be rendered in markdown. Descriptions in event lists will be truncated by first removing all elements except paragraphs and links and then truncating to make sure we don't kill any formatting by cutting at the wrong spot. If it turns out that people always start their descriptions with lists, we will probably have to be a bit more sophisticated here.