### PR TITLE
Allow simultaneously sorting and filtering the applicants list

### DIFF
--- a/app/helpers/applicants_overview_helper.rb
+++ b/app/helpers/applicants_overview_helper.rb
@@ -1,8 +1,11 @@
 module ApplicantsOverviewHelper
   def sort_caret(label, attr)
     is_sorted_ascending = (params[:sort] == attr.to_s) && params[:order] != 'descending'
+    url = "?sort=#{attr.to_s}" +
+      "#{'&order=descending' if is_sorted_ascending}" +
+      "#{'&' + params[:filter].map { |k,v| "filter[#{k}]=#{v}" }.join('&') if params[:filter]}"
 
-    "<a class=\"#{'dropup' if is_sorted_ascending}\" href=\"?sort=#{attr.to_s}#{'&order=descending' if is_sorted_ascending}\">
+    "<a class=\"#{'dropup' if is_sorted_ascending}\" href=\"#{url}\">
       #{label} <span class=\"caret\"></span>
     </a>".html_safe
   end

--- a/app/views/application_letters/_application_filter_popover.html.erb
+++ b/app/views/application_letters/_application_filter_popover.html.erb
@@ -7,5 +7,7 @@
       <% end %>
       <br>
     <% end %>
+    <%= hidden_field_tag 'sort', params[:sort] if params[:sort] %>
+    <%= hidden_field_tag 'order', params[:order] if params[:order] %>
     <input class="btn btn-default btn-sm" type="submit" value="<%= t 'events.applicants_overview.filter' %>">
 </form>

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -253,7 +253,7 @@ RSpec.feature "Event application letters overview on event page", :type => :feat
     expect(page).to contain_ordered(names.reverse)
   end
 
-  scenario "logged in as Organizer I can filter displayed application letters by their status", js: true do
+  scenario "logged in as Organizer I can filter displayed application letters by their status and simultaneously sort them", js: true do
     login(:organizer)
     @event = FactoryGirl.create(:event_with_accepted_applications)
     @event.application_letters.each do |letter|
@@ -271,6 +271,17 @@ RSpec.feature "Event application letters overview on event page", :type => :feat
     expect(page).to have_every_text(accepted_names)
     expect(page).to have_no_text(not_accepted_names)
 
+    # sort this list by name
+    click_link I18n.t('activerecord.attributes.profile.name')
+
+    sorted_accepted_names = @event.application_letters
+      .to_a
+      .sort_by { |letter| letter.applicant_age_when_event_starts }
+      .select { |letter| letter.status.to_sym == :accepted }
+      .map {|l| l.user.profile.name }
+    expect(page).to contain_ordered(sorted_accepted_names)
+
+    # list rejected, pending
     click_button I18n.t 'events.applicants_overview.filter_by'
     uncheck I18n.t 'application_status.accepted'
     check I18n.t 'application_status.rejected'


### PR DESCRIPTION
Simply pass the parameters on all the requests that trigger filter/sort.