### PR TITLE
Fix error text color, fix count on error message, fix layout on requests

### DIFF
--- a/app/assets/stylesheets/custom_bootstrap/variables.less
+++ b/app/assets/stylesheets/custom_bootstrap/variables.less
@@ -237,8 +237,8 @@
 @state-warning-text: rgb(255, 255, 255);
 @state-warning-bg: @brand-warning;
 @state-warning-border: darken(spin(@state-warning-bg, -10), 3%);
-@state-danger-text: rgb(255, 255, 255);
-@state-danger-bg: @brand-danger;
+@state-danger-text: @brand-danger;
+@state-danger-bg: #f2dede;
 @state-danger-border: darken(spin(@state-danger-bg, -10), 3%);
 @tooltip-max-width: 200px;
 @tooltip-color: rgb(255, 255, 255);

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -40,7 +40,9 @@
               <%= I18n.t :"requests.form_of_addresses.#{key}" %>
             </label>
         <% end %>
-        <%= f.error_span(:form_of_address) %>
+      </div>
+      <div class="col-lg-offset-2 col-lg-10">
+          <%= f.error_span(:form_of_address) %>
       </div>
     </div>
 

--- a/app/views/shared/_error_message.html.erb
+++ b/app/views/shared/_error_message.html.erb
@@ -1,6 +1,7 @@
 <% if entity.errors.any? %>
   <div id="error_expl" class="panel panel-danger">
     <div class="panel-heading">
-      <h3 class="panel-title"><%=I18n.t("errors.form_invalid", count: entity.errors.count) %></h3> </div>
+	  <% p entity.errors %>
+      <h3 class="panel-title"><%=I18n.t("errors.form_invalid", count: entity.errors.messages.count) %></h3> </div>
   </div>
 <% end %>

--- a/app/views/shared/_error_message.html.erb
+++ b/app/views/shared/_error_message.html.erb
@@ -1,7 +1,6 @@
 <% if entity.errors.any? %>
   <div id="error_expl" class="panel panel-danger">
     <div class="panel-heading">
-	  <% p entity.errors %>
       <h3 class="panel-title"><%=I18n.t("errors.form_invalid", count: entity.errors.messages.count) %></h3> </div>
   </div>
 <% end %>


### PR DESCRIPTION
The color scheme branch set the text color of all errors to white, hoping that they would always have a red background, which was not the case. This reverses to the default bootstrap error colors.

Furthermore, this makes the global error partial a little more smart, by counting the number of messages, instead of errors, which corresponds to the number of fields errors appeared in instead of the global number of errors. (So no more "In 9 Feldern sind Fehler" while you actually only have 8 fields).

And lastly, an error span on the requests page was incorrectly placed, breaking the layout of the btn-group.