### PR TITLE
Revert "Set mail host in config. Fixes #299."

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,10 +77,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = ENV['RAILS_HOST'].present? ?
-    { :host => ENV['RAILS_HOST'], :port => ENV['RAILS_PORT'] } :
-    ActionMailer::Base.default_url_options
-
   config.action_mailer.delivery_method = :smtp
   # SMTP settings for gmail
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Reverts hpi-swt2/workshop-portal#367
Doesn't work. Take a look at the [heroku log](https://github.com/hpi-swt2/workshop-portal/files/725220/herokulogEmailDefault.txt).
Kind of urgent since this lets all new builds fail on heroku. It stays usable, but without the latest changes.