### PR TITLE
QUICKFIX make email button visible in execution phase

### DIFF
--- a/app/views/events/_applicants_overview.html.erb
+++ b/app/views/events/_applicants_overview.html.erb
@@ -66,7 +66,7 @@
     </div>
 
     <div class="btn-group pull-right" role="group">
-      <% if  (can? :send_email, Email) && (@event.phase == :selection) %>
+      <% if  (can? :send_email, Email) && ((@event.phase == :selection)||(@event.phase == :execution)) %>
         <% if not @event.applications_classified? %>
           <div class="btn-group pull-right tooltip-wrapper has-tooltip" role="group" data-toggle="tooltip" title="<%= t '.unclassified_applications_left'%>">
             <%= button_tag t('.sending_acceptances'), type: 'button', class: 'send-emails-button btn btn-default', disabled: true %>

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "events/show", type: :view do
       end
     end
   end
-  
+
   it "displays correct buttons in draft phase" do
     @event = assign(:event, FactoryGirl.create(:event, :in_draft_phase))
     sign_in(FactoryGirl.create(:user, role: :organizer))
@@ -188,8 +188,8 @@ RSpec.describe "events/show", type: :view do
     render
     expect(rendered).to_not have_link(t(:print_all, scope: 'events.applicants_overview'))
     expect(rendered).to_not have_link(t(:accept_all, scope: 'events.applicants_overview'))
-    expect(rendered).to_not have_link(t(:sending_acceptances, scope: 'events.applicants_overview'))
-    expect(rendered).to_not have_link(t(:sending_rejections, scope: 'events.applicants_overview'))
+    expect(rendered).to have_link(t(:sending_acceptances, scope: 'events.applicants_overview'))
+    expect(rendered).to have_link(t(:sending_rejections, scope: 'events.applicants_overview'))
     expect(rendered).to have_link(t(:show_participants, scope: 'events.participants'))
     expect(rendered).to_not have_button(t(:sending_acceptances, scope: 'events.applicants_overview'), disabled: true)
     expect(rendered).to_not have_button(t(:sending_rejections, scope: 'events.applicants_overview'), disabled: true)


### PR DESCRIPTION
Quickfix for presentation on friday

Emails buttons are now also visible in execution phase, so you can always send both mails

This should be changed (execution phase starts after both mails are sent) in the future