### PR TITLE
Check for blank? instead of empty? to also catch nil values.

### DIFF
--- a/app/views/events/_show_event_large.html.erb
+++ b/app/views/events/_show_event_large.html.erb
@@ -29,13 +29,13 @@
   </div>
   <div class="col-md-2 col-sm-offset-2 col-md-offset-0">
     <dl>
-      <% if not @event.knowledge_level.empty? or can? :manage, Event %>
+      <% if not @event.knowledge_level.blank? or can? :manage, Event %>
         <dt><strong><%= model_class.human_attribute_name(:knowledge_level) %>:</strong></dt>
         <dd><%= @event.knowledge_level %></dd>
       <% end %>
       <dt><strong><%= model_class.human_attribute_name(:max_participants) %>:</strong></dt>
       <dd><%= @event.max_participants %></dd>
-      <% if not @event.organizer.empty? or can? :manage, Event %>
+      <% if not @event.organizer.blank? or can? :manage, Event %>
         <dt><strong><%= model_class.human_attribute_name(:organizer) %>:</strong></dt>
         <dd><%= @event.organizer %></dd>
       <% end %>

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe "events/show", type: :view do
     expect(rendered).to_not have_text(Event.human_attribute_name(:organizer))
   end
 
+  it "does not render knowledge level or organizer if nil and the user isn't organizer" do
+    @event = assign(:event, FactoryGirl.create(:event, knowledge_level: nil, organizer: nil))
+    sign_in(FactoryGirl.create(:user, role: :pupil))
+
+    render
+    expect(rendered).to_not have_text(Event.human_attribute_name(:knowledge_level))
+    expect(rendered).to_not have_text(Event.human_attribute_name(:organizer))
+  end
+
   it "does render knowledge level or organizer if empty and the user is organizer" do
     @event = assign(:event, FactoryGirl.create(:event, knowledge_level: '', organizer: ''))
     sign_in(FactoryGirl.create(:user, role: :organizer))


### PR DESCRIPTION
Fixes errors on the event view page if knowledge level or organizer are `nil`.
