### PR TITLE
Force one event in the sample data to be in the past. Remove fadeout. Fixes #304.

### DIFF
--- a/app/assets/stylesheets/events.css
+++ b/app/assets/stylesheets/events.css
@@ -48,9 +48,6 @@
     margin: 15px 0;
     padding-bottom: 15px;
 }
-.event-preview.event-past {
-    opacity: 0.7;
-}
 .front-section:nth-child(even) .event-preview {
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,4 +1,4 @@
-<div class="event-preview media <%= 'event-past' if event.is_past %> clearfix">
+<div class="event-preview media clearfix">
   <%= image_tag "example.png", class: "img-rounded img-responsive img-float-corner-tr center-block" %>
   <div class="media-left">
     <%= render "events/event_date_large", event: event %>

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -10,11 +10,14 @@ def add_sample_data
 
   events[:programmierkurs] = event_programmierkurs
   events[:mintcamp] = event_mintcamp
-  events[:bechersaeuberungsevent] = event_bechersaeuberungsevent
   events[:gongakrobatik] = event_gongakrobatik
   events[:batterie_akustik] = event_batterie_akustik
   events[:bachlorpodium] = event_bachlorpodium
   events[:past_deadline_event] = event_gongakrobatik
+
+  # past events are not valid by definition, however we
+  # would like to pretend to have some old ones
+  event_bechersaeuberungsevent.save!(validate: false)
 
   users = Hash.new
   users[:pupil] = user_pupil

--- a/db/sample_data/events.rb
+++ b/db/sample_data/events.rb
@@ -42,10 +42,11 @@ def event_mintcamp
 end
 
 def event_bechersaeuberungsevent
-  date_range_singleday = DateRange.create!(
-      start_date: Date.new(2017, 04, 04),
-      end_date: Date.new(2017, 04, 05)
+  date_range_singleday = DateRange.new(
+      start_date: Date.yesterday,
+      end_date: Date.yesterday
   )
+  date_range_singleday.save!(validate: false)
   Event.new(
       name: 'Bechersäuberungsevent',
       description: 'Es dreht sich den ganzen Tag um das Säubern von Bechern. Wie säubert man einen Becher am effizientesten oder am schnellsten? Wie immer bieten wir eine Reihe an Expertenvorträgen an. Dieses Mal erfahrt ihr unter anderem wie ihr Edding-Markierungen selbst nach einer Spülmaschinen-Reinigung noch entfernen könnt oder wie man die richtige Größe für Becher-Stapel herausfindet und anwendet.',
@@ -53,7 +54,7 @@ def event_bechersaeuberungsevent
       organizer: 'FSR',
       knowledge_level: 'Anfänger',
       date_ranges: [date_range_singleday],
-      application_deadline: Date.tomorrow,
+      application_deadline: Date.yesterday.prev_day(2),
       application_status_locked: false,
       published: true,
       hidden: false,


### PR DESCRIPTION
As a suggested solution to avoid dropping all the validations (which, at the time of creation of an event of course make a lot of sense), I now made the sample data force create one past event (the Bechersäuberungsevent), so that the functionality can be tested. Is this okay @tobiduer ?

(Furthermore, I removed the now unnecessary fadeout on past events)