### PR TITLE
243 3.26 send emails for acceptance of alternatives

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -49,7 +49,7 @@ class EmailsController < ApplicationController
       @event.set_status_notification_flag_for_applications_with_status(application_letter_status)
       if status == :acceptance
         @event.acceptances_have_been_sent = true
-        if not @event.has_rejected_participants_without_status_notification?
+        if not @event.has_participants_without_status_notification?(:rejected)
           @event.rejections_have_been_sent = true
         end
       elsif status == :rejection

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -228,12 +228,12 @@ class Event < ActiveRecord::Base
     application_letters.where(status: ApplicationLetter.statuses[:accepted]).count
   end
 
-  # Returns whether there are rejected applications with no status notification sent of the event
+  # Returns whether there are applications of given state with no status notification sent of the event
   #
-  # @param none
-  # @return [Boolean] true if there are rejected participants without status notification sent
-  def has_rejected_participants_without_status_notification?
-    application_letters.exists?(status: ApplicationLetter.statuses[:rejected], status_notification_sent: false)
+  # @param [Symbol] status
+  # @return [Boolean] true if there are participants of given state without status notification sent
+  def has_participants_without_status_notification?(status)
+    application_letters.exists?(status: ApplicationLetter.statuses[status], status_notification_sent: false)
   end
 
   # Returns the current state of the event (draft-, application-, selection- and execution-phase)

--- a/app/views/application_letters/_application_selective.html.erb
+++ b/app/views/application_letters/_application_selective.html.erb
@@ -5,16 +5,16 @@
             <% if application_letter.status.to_sym == :accepted %>
                 <% if application_letter.status_notification_sent %>                
                     <%= link_to t('application_status.actions.cancel'), update_application_letter_status_path(application_letter, 'application_letter[status]': :canceled),
-                            method: :put, class: 'btn btn-default' %>
+                            method: :put, class: 'btn btn-sm btn-default' %>
                 <% else %>
-                    <span class="glyphicon glyphicon-envelope">
+                    <span class="glyphicon glyphicon-envelope"></span>
                 <% end %>
             <% elsif application_letter.status.to_sym == :alternative && @has_free_places %>
                 <%= link_to t('application_status.actions.accept'), update_application_letter_status_path(application_letter, 'application_letter[status]': :accepted),
-                            method: :put, class: 'btn btn-default' %>
+                            method: :put, class: 'btn btn-sm btn-default' %>
             <% elsif application_letter.status.to_sym == :rejected && @has_free_places && !application_letter.event.has_alternative_application_letters? %>
                 <%= link_to t('application_status.actions.accept'), update_application_letter_status_path(application_letter, 'application_letter[status]': :accepted),
-                            method: :put, class: 'btn btn-default' %>
+                            method: :put, class: 'btn btn-sm btn-default' %>
             <% end %>
         <% end %>
     <% elsif application_letter.event.phase == :selection %>

--- a/app/views/events/_applicants_overview.html.erb
+++ b/app/views/events/_applicants_overview.html.erb
@@ -62,29 +62,23 @@
         <%= link_to t('.print_all'), print_applications_event_path(@event.to_param), :target => "_blank", :class => 'btn btn-default' %>
       <% end %>
     </div>
-
-    <% if (can? :send_email, Email) && (@event.phase == :selection) %>
-      <% if not @event.acceptances_have_been_sent %>
-      <div class="btn-group send-emails-buttons pull-right tooltip-wrapper has-tooltip" role="group" data-toggle="tooltip" title="<%= @event.send_mails_tooltip %>">
-        <%= form_tag event_email_show_path(@event), method: :get do %>
-          <%= hidden_field_tag "status", "acceptance" %>
-          <%= button_tag t('.sending_acceptances'), class: 'send-emails-button btn btn-default', disabled: @event.send_mails_tooltip.present? %>
+    <% if can? :send_email, Email %>
+      <% if @event.phase == :selection %>
+        <% if not @event.acceptances_have_been_sent %>
+          <%= render partial: 'send_mail_button', locals: {button_label: t('.sending_acceptances'), template_status: "acceptance"} %>
         <% end %>
-      </div>
-      <% end %>
-      <% if not @event.rejections_have_been_sent %>
-      <div class="btn-group send-emails-buttons pull-right tooltip-wrapper has-tooltip" role="group" data-toggle="tooltip" title="<%= @event.send_mails_tooltip %>">
-        <%= form_tag event_email_show_path(@event), method: :get do %>
-          <%= hidden_field_tag "status", "rejection" %>
-          <%= button_tag t('.sending_rejections'), class: 'send-emails-button btn btn-default', disabled: @event.send_mails_tooltip.present? %>
+        <% if not @event.rejections_have_been_sent %>
+              <%= render partial: 'send_mail_button', locals: {button_label: t('.sending_rejections'), template_status: "rejection"} %>
         <% end %>
-      </div>
+      <% elsif (@event.phase == :execution) && @event.has_participants_without_status_notification?(:accepted) %>
+          <%= render partial: 'send_mail_button', locals: {button_label: t('.sending_acceptances'), template_status: "acceptance"} %>
       <% end %>
     <% end %>
 
     <% if (can? :view_participants, Event) && (@event.phase == :execution) %>
       <%= link_to t('events.participants.show_participants'),
-                  event_path(@event) + "/participants" , :class => 'btn btn-primary btn-sm pull-right'  %>
+                  event_path(@event) + "/participants" , :class => 'btn btn-primary pull-right'  %>
+
     <% end %>
   </div>
 </div>

--- a/app/views/events/_send_mail_button.html.erb
+++ b/app/views/events/_send_mail_button.html.erb
@@ -1,0 +1,6 @@
+<div class="btn-group send-emails-buttons pull-right tooltip-wrapper has-tooltip" role="group" data-toggle="tooltip" title="<%= @event.send_mails_tooltip %>">
+  <%= form_tag event_email_show_path(@event), method: :get do %>
+      <%= hidden_field_tag "status", template_status %>
+      <%= button_tag button_label, class: 'send-emails-button btn btn-default', disabled: @event.send_mails_tooltip.present? %>
+  <% end %>
+</div>

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -244,6 +244,15 @@ RSpec.feature "Event application letters overview on event page", :type => :feat
     expect(page).to_not have_link(I18n.t("application_status.actions.accept"), href: update_application_letter_status_path(@application_letter, 'application_letter[status]': :accepted))
   end
 
+  scenario "logged in as Organizer I can send emails to accepted alternatives who got no acceptance mail yet (execution phase)" do
+    login(:organizer)
+    @event = FactoryGirl.create(:event_in_execution_with_applications_in_various_states, :with_no_status_notification_sent, accepted_application_letters_count: 1)
+    @application_letter = @event.application_letters.find { |application| application.status == 'accepted'}
+    visit event_path(@event)
+    expect(page).to have_button(I18n.t('events.applicants_overview.sending_acceptances'))
+    click_button(I18n.t('events.applicants_overview.sending_acceptances'))
+    expect(page).to have_selector("input#email_recipients[value='#{@application_letter.user.email}']")
+  end
 
   scenario "logged in as Organizer I can send acceptance and then rejection emails and by that change the status notification flag" do
     login(:organizer)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -184,14 +184,14 @@ describe Event do
     expect(event.compute_occupied_places).to eq(2)
   end
 
-  it "computes whether there are rejected applications with no status notification sent yet" do
+  it "computes whether there are applications with no status notification sent yet" do
     event = FactoryGirl.create(:event, :in_selection_phase_with_no_mails_sent)
     FactoryGirl.create(:application_letter_accepted, user: FactoryGirl.create(:user), event: event)
-    expect(event.has_rejected_participants_without_status_notification?).to eq(false)
+    expect(event.has_participants_without_status_notification?(:accepted)).to eq(true)
     FactoryGirl.create(:application_letter_rejected, :with_mail_sent, user: FactoryGirl.create(:user), event: event)
-    expect(event.has_rejected_participants_without_status_notification?).to eq(false)
+    expect(event.has_participants_without_status_notification?(:rejected)).to eq(false)
     FactoryGirl.create(:application_letter_rejected, user: FactoryGirl.create(:user), event: event)
-    expect(event.has_rejected_participants_without_status_notification?).to eq(true)
+    expect(event.has_participants_without_status_notification?(:rejected)).to eq(true)
   end
 
   it "returns all Events running now and in the future" do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -280,6 +280,18 @@ RSpec.describe "events/show", type: :view do
     expect(rendered).to_not have_button(t(:sending_rejections, scope: 'events.applicants_overview'), disabled: true)
   end
 
+  it "displays correct buttons in execution phase when there are alternatives accepted with no status notification sent" do
+    @event = assign(:event, FactoryGirl.create(:event_in_execution_with_applications_in_various_states, :with_no_status_notification_sent, accepted_application_letters_count: 1))
+    assign(:has_free_places, @event.compute_free_places > 0)
+    sign_in(FactoryGirl.create(:user, role: :organizer))
+    render
+    expect(rendered).to_not have_link(t(:print_all, scope: 'events.applicants_overview'))
+    expect(rendered).to_not have_link(t(:accept_all, scope: 'events.applicants_overview'))
+    expect(rendered).to have_button(t(:sending_acceptances, scope: 'events.applicants_overview'))
+    expect(rendered).to_not have_button(t(:sending_rejections, scope: 'events.applicants_overview'))
+    expect(rendered).to have_link(t(:show_participants, scope: 'events.participants'))
+  end
+
   it "should display particiants button when email were already sent as organizer" do
     @event = assign(:event, FactoryGirl.create(:event, :in_execution_phase))
     assign(:has_free_places, @event.compute_free_places > 0)


### PR DESCRIPTION
Adds possibility to send emails to accepted alternatives - haha.
- After you accepted an alternative, you are now able to "actually" accept him via sending an email
- Refactor has_rejected_participants_without_status_notification? to be more general
- Outsource send mail button to partial