### PR TITLE
Fix Heroku deploys

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec rake db:migrate
 web: bundle exec puma -C config/puma.rb

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "workshop-portal",
   "scripts": {
-    "postdeploy": "bundle exec rake db:schema:load db:seed"
+    "postdeploy": "bundle exec rake db:schema:load db:seed db:populate_sample_data"
   },
   "env": {
     "LANG": {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "name": "workshop-portal",
   "scripts": {
+    "postdeploy": "bundle exec rake db:schema:load db:seed"
   },
   "env": {
     "LANG": {

--- a/db/migrate/20161129120651_add_default_value_to_application_status.rb
+++ b/db/migrate/20161129120651_add_default_value_to_application_status.rb
@@ -1,6 +1,6 @@
 class AddDefaultValueToApplicationStatus < ActiveRecord::Migration
   def change
-    change_column :application_letters, :status, :integer, default: 2
+    change_column :application_letters, :status, 'integer USING CAST(status AS integer)', default: 2
     change_column_null :application_letters, :status, false, 2
   end
 end


### PR DESCRIPTION
Probably due to a Postgres update, the database now is more restrictive when it comes to changing a column's type. The Heroku deployment failed for this reason. I have already confirmed this fix to be working by manually applying it to the currently deployed version. You'll see it running over here: http://workshopportal.herokuapp.com/

Things left to do:
- [x] Verify this doesn't break SQLite migrations. (i.e. destroy your SQLite database and see if `rake db:migrate` works afterwards)