### PR TITLE
Better translation for welcome message

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -47,7 +47,7 @@ de:
         remember_me: "Eingeloggt bleiben"
   midnight: "Mitternacht"
   start_page:
-    welcome_to: "Herzlich Willkommen im"
+    welcome_to: "Herzlich Willkommen beim"
     workshop_portal_hpi_html: "Workshop<div class='row spacer-15'></div>Portal des HPI."
     register_now: "Registrieren"
     place_request: "Anfrage stellen"


### PR DESCRIPTION
It now says:
> Herzlich Willkommen beim
Workshop
Portal des HPI.
